### PR TITLE
Remove CiviCRM specific TS wrapper in the exception causing a undefin…

### DIFF
--- a/lib/CiviCRM/API3/Exception.php
+++ b/lib/CiviCRM/API3/Exception.php
@@ -28,7 +28,7 @@ class Exception extends \Exception {
     // using int for error code "old way")
     $code = is_numeric($error_code) ? $error_code : 0;
 
-    parent::__construct(ts($message), $code, $previous);
+    parent::__construct($message, $code, $previous);
     $this->extraParams = $extraParams + array('error_code' => $error_code);
   }
 


### PR DESCRIPTION
"Remove CiviCRM specific TS wrapper function in the exception causing a undefined function in cases where the CiviCRM framework is not present."

The ts() function seems to be specific to civicrm as far as I can tell. Removing it resulted in the proper display of exceptions.

Thanks