### PR TITLE
Change ts() to t() in Exception.php for D8 compatibility

### DIFF
--- a/lib/CiviCRM/API3/Exception.php
+++ b/lib/CiviCRM/API3/Exception.php
@@ -28,7 +28,7 @@ class Exception extends \Exception {
     // using int for error code "old way")
     $code = is_numeric($error_code) ? $error_code : 0;
 
-    parent::__construct(ts($message), $code, $previous);
+    parent::__construct(t($message), $code, $previous);
     $this->extraParams = $extraParams + array('error_code' => $error_code);
   }
 


### PR DESCRIPTION
This minor changes makes the repo work within a D8 project as well without causing a fatal error.